### PR TITLE
Remove getting current block in get_unitap_pass_holders

### DIFF
--- a/brightIDfaucet/celery.py
+++ b/brightIDfaucet/celery.py
@@ -82,8 +82,8 @@ app.conf.beat_schedule = {
         "schedule": 600,
     },
     "update_prizetap_winning_chance_number_every_week": {
-        "task": "prizetap.task.update_prizetap_winning_chance_number",
-        "schedule": crontab(minute="*/2"),
+        "task": "prizetap.tasks.update_prizetap_winning_chance_number",
+        "schedule": crontab(minute="0", hour="0", day_of_week="1"),
     },
 }
 

--- a/core/thirdpartyapp/subgraph.py
+++ b/core/thirdpartyapp/subgraph.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 from core.request_helper import RequestException, RequestHelper
 from core.thirdpartyapp import config
-from core.utils import Web3Utils
 
 
 class Subgraph:
@@ -15,15 +14,6 @@ class Subgraph:
 
     def __del__(self):
         self.session.close()
-
-    @staticmethod
-    def get_current_block_number():
-        from core.models import Chain
-
-        eth_chain = Chain.objects.get(chain_id=1)
-        w3 = Web3Utils(eth_chain.rpc_url_private)
-        current_block_number = w3.get_current_block()
-        return current_block_number
 
     def send_post_request(self, path, query, vars, **kwargs):
         try:
@@ -43,16 +33,17 @@ class Subgraph:
 
         count = 0
         holders = defaultdict(set)
-        current_block_number = self.get_current_block_number()
         query = """
         query GetNFTHolders($first: Int, $skip: Int, $block_number: Int) {
-            nfts (first: $first, skip: $skip, block: {number: $number}) {
+            nfts (first: $first, skip: $skip) {
                 tokenId,
                 owner
             }
         }
         """
-        vars = {"first": first, "block_number": current_block_number - 1}
+        vars = {
+            "first": first,
+        }
 
         while True:
             res = self.send_post_request(


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request simplifies the `get_unitap_pass_holders` method by removing the retrieval of the current block number and updates the schedule for the `update_prizetap_winning_chance_number` task to run weekly.

- **Enhancements**:
    - Removed the retrieval of the current block number in the `get_unitap_pass_holders` method to simplify the query parameters.
- **Chores**:
    - Updated the schedule for the `update_prizetap_winning_chance_number` task to run weekly instead of every 2 minutes.

<!-- Generated by sourcery-ai[bot]: end summary -->