### PR TITLE
Add prizetap_winning_chance_number to RaffleEnrollmentView

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -144,6 +144,8 @@ class ProfileSerializer(serializers.ModelSerializer):
             "prizetap_winning_chance_number",
         ]
 
+        read_only_fields = ("prizetap_winning_chance_number",)
+
     def get_token(self, instance):
         token, bol = Token.objects.get_or_create(user=instance.user)
         return token.key
@@ -162,6 +164,7 @@ class SimpleProfilerSerializer(serializers.ModelSerializer):
             "wallets",
             "prizetap_winning_chance_number",
         ]
+        read_only_fields = ("prizetap_winning_chance_number",)
 
     def get_username(self, user_profile: UserProfile):
         if not user_profile.username:

--- a/core/tests.py
+++ b/core/tests.py
@@ -309,7 +309,7 @@ class TestGitcoinPassportConstraint(BaseTestCase):
         create_new_wallet(
             user_profile=self.user_profile, _address=self.address, wallet_type="EVM"
         )
-        self.minimum = 10
+        self.minimum = 1
 
         self.gp = GitcoinPassportConnection.objects.create(
             user_wallet_address=self.address, user_profile=self.user_profile

--- a/prizetap/views.py
+++ b/prizetap/views.py
@@ -1,6 +1,8 @@
 import json
 
 import rest_framework.exceptions
+from django.db import transaction
+from django.db.models import F
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from drf_yasg.utils import swagger_auto_schema
@@ -11,6 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from authentication.models import UserProfile
 from core.constraints import ConstraintVerification, get_constraint
 from core.models import Chain
 from core.serializers import ChainSerializer
@@ -59,7 +62,7 @@ class RaffleEnrollmentView(CreateAPIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request, pk):
-        user_profile = request.user.profile
+        user_profile: UserProfile = request.user.profile
         raffle = get_object_or_404(Raffle, pk=pk)
         user_wallet_address = request.data.get("user_wallet_address", None)
         if not user_wallet_address:
@@ -70,16 +73,25 @@ class RaffleEnrollmentView(CreateAPIView):
         validator = RaffleEnrollmentValidator(user_profile=user_profile, raffle=raffle)
 
         validator.is_valid(self.request.data)
+        prizetap_winning_chance_number = int(
+            self.request.data.get("prizetap_winning_chance_number", 0)
+        )
 
         try:
             raffle_entry = raffle.entries.get(user_profile=user_profile)
         except RaffleEntry.DoesNotExist:
-            raffle_entry = RaffleEntry.objects.create(
-                user_profile=user_profile,
-                user_wallet_address=user_wallet_address,
-                raffle=raffle,
-            )
-            raffle_entry.save()
+            with transaction.atomic():
+                user_profile.prizetap_winning_chance_number = (
+                    F("prizetap_winning_chance_number") - prizetap_winning_chance_number
+                )
+                user_profile.save(update_fields=("prizetap_winning_chance_number",))
+                raffle_entry = RaffleEntry.objects.create(
+                    user_profile_id=user_profile.pk,
+                    user_wallet_address=user_wallet_address,
+                    raffle=raffle,
+                    multiplier=prizetap_winning_chance_number + 1,
+                )
+                raffle_entry.save()
 
         return Response(
             {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the raffle enrollment process by adding support for 'prizetap_winning_chance_number'. It includes validation logic to ensure the number is within acceptable limits and updates the RaffleEnrollmentView to handle this new field. Additionally, new test cases have been added to cover various validation scenarios.

- **Enhancements**:
    - Added validation logic for 'prizetap_winning_chance_number' in RaffleEnrollmentValidator to ensure the value is within acceptable limits.
    - Updated RaffleEnrollmentView to handle 'prizetap_winning_chance_number' during raffle enrollment, including decrementing the user's available chances and setting a multiplier for the raffle entry.
- **Tests**:
    - Added multiple test cases to validate the 'prizetap_winning_chance_number' during raffle enrollment, including scenarios for negative values, values greater than allowed, and insufficient chances.

<!-- Generated by sourcery-ai[bot]: end summary -->