### PR TITLE
bugfix

### DIFF
--- a/prizetap/tasks.py
+++ b/prizetap/tasks.py
@@ -303,7 +303,8 @@ def process_raffles_pre_enrollments(self):
 
         with transaction.atomic():
             queryset = (
-                Raffle.objects.filter(pre_enrollment_file__isnull=False)
+                Raffle.objects.exclude(pre_enrollment_file__isnull=True)
+                .exclude(pre_enrollment_file__exact="")
                 .filter(status=Raffle.Status.VERIFIED)
                 .filter(is_processed=False)
                 .order_by("id")


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the raffle processing logic by ensuring that raffles with empty pre-enrollment files are excluded from the query.

- **Bug Fixes**:
    - Fixed an issue where raffles with empty pre-enrollment files were incorrectly included in the processing query.

<!-- Generated by sourcery-ai[bot]: end summary -->