### PR TITLE
Fix/prizetap

### DIFF
--- a/prizetap/tasks.py
+++ b/prizetap/tasks.py
@@ -347,7 +347,7 @@ def process_raffles_pre_enrollments(self):
                     entry = RaffleEntry(
                         raffle=raffle,
                         user_profile=user_profile,
-                        user_wallet_address=row[0],
+                        user_wallet_address=Web3.to_checksum_address(row[0]),
                         multiplier=row[1],
                         pre_enrollment=True,
                     )
@@ -367,11 +367,17 @@ def onchain_pre_enrollments(self):
         entries_queryset = (
             RaffleEntry.objects.filter(pre_enrollment=True)
             .filter(tx_hash__isnull=True)
+            .exclude(raffle__deadline__lt=timezone.now())
             .order_by("id")
         )
         batch_size = 50
         if entries_queryset.count() > 0:
             first_entry = entries_queryset.first()
+
+            print(
+                f"Perform onchain transaction of the raffle {first_entry.raffle.pk}"
+                " pre-enrollments"
+            )
 
             batch_entry = entries_queryset.filter(raffle=first_entry.raffle).all()[
                 :batch_size


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug related to user wallet addresses by converting them to checksum addresses. It also enhances the onchain pre-enrollments process by excluding past-deadline raffles and adding logging for transaction initiation.

- **Bug Fixes**:
    - Fixed the issue with user wallet addresses by converting them to checksum addresses using Web3.to_checksum_address.
- **Enhancements**:
    - Added a filter to exclude raffles with deadlines in the past from the onchain pre-enrollments process.
    - Included a print statement to log the initiation of onchain transactions for raffle pre-enrollments.

<!-- Generated by sourcery-ai[bot]: end summary -->