### PR TITLE
refactor web3

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -11,6 +11,7 @@ from django.core.cache import cache
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import UploadedFile
 from django.utils import timezone
+from eth_account.datastructures import SignedTransaction
 from eth_account.messages import encode_defunct
 from solana.rpc.api import Client
 from web3 import Account, Web3
@@ -199,8 +200,8 @@ class Web3Utils:
     def sign_tx(self, tx_data: TxParams):
         return self.w3.eth.account.sign_transaction(tx_data, self.account.key)
 
-    def send_raw_tx(self, signed_tx):
-        return self.w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    def send_raw_tx(self, signed_tx: SignedTransaction):
+        return self.w3.eth.send_raw_transaction(signed_tx.raw_transaction)
 
     def wait_for_transaction_receipt(self, tx_hash):
         return self.w3.eth.wait_for_transaction_receipt(tx_hash)

--- a/prizetap/utils.py
+++ b/prizetap/utils.py
@@ -94,7 +94,9 @@ class PrizetapContractClient:
         func = self.web3_utils.contract.functions.batchParticipate(
             self.raffle.raffleId, participants, multipliers
         )
-        return self.web3_utils.contract_txn(func)
+        tx_hash = self.web3_utils.contract_txn(func)
+        self.web3_utils.wait_for_transaction_receipt(tx_hash)
+        return tx_hash
 
 
 class VRFClientContractClient:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the web3-related utility functions by updating type annotations, improving method implementations, and ensuring transaction receipts are awaited before returning transaction hashes.

- **Enhancements**:
    - Updated type annotations for the send_raw_tx method in core/utils.py to use SignedTransaction.
    - Modified send_raw_tx method to use signed_tx.raw_transaction instead of signed_tx.rawTransaction in core/utils.py.
    - Enhanced batch_participate method in prizetap/utils.py to wait for transaction receipt before returning the transaction hash.

<!-- Generated by sourcery-ai[bot]: end summary -->