### PR TITLE
bugfix

### DIFF
--- a/prizetap/serializers.py
+++ b/prizetap/serializers.py
@@ -204,6 +204,8 @@ class RaffleSerializer(serializers.ModelSerializer):
 
     def get_user_entry(self, raffle: Raffle):
         try:
+            if not self.context["user"]:
+                return None
             return RaffleEntrySerializer(
                 raffle.entries.get(user_profile=self.context["user"])
             ).data


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the get_user_entry method of the prizetap/serializers.py file. The fix ensures that the method returns None if the user context is not available, thereby preventing potential crashes.

- **Bug Fixes**:
    - Fixed a bug in the get_user_entry method to handle cases where the user context is not provided, preventing potential crashes.

<!-- Generated by sourcery-ai[bot]: end summary -->