### PR TITLE
Prizetap: set pre-enrollment profiles

### DIFF
--- a/prizetap/views.py
+++ b/prizetap/views.py
@@ -49,6 +49,8 @@ class RaffleListView(ListAPIView):
 
     def get(self, request):
         queryset = self.get_queryset()
+        if request.user.is_authenticated:
+            RaffleEntry.set_entry_user_profiles(request.user)
         serializer = RaffleSerializer(
             queryset,
             many=True,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhanced the `RaffleEntry` model by adding a class method to set user profiles for raffle entries. Updated the `RaffleListView` to call this method when the user is authenticated.

- **Enhancements**:
    - Added a class method `set_entry_user_profiles` to the `RaffleEntry` model to associate user profiles with raffle entries based on wallet addresses.

<!-- Generated by sourcery-ai[bot]: end summary -->