### PR TITLE
Fix test in twitter constraint

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -396,6 +396,7 @@ class TestTwitterConstraint(BaseTestCase):
             oauth_token_secret=oauth_token_secret,
             access_token="test",
             access_token_secret="test",
+            twitter_id="1",
         )
 
         self.not_connected_user_profile = UserProfile.objects.create(


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix a test in the Twitter constraint by adding the missing 'twitter_id' field to ensure the test setup is complete and accurate.

Bug Fixes:
- Fix a test in the Twitter constraint by adding a missing 'twitter_id' field to the setup of a user profile.

<!-- Generated by sourcery-ai[bot]: end summary -->