### PR TITLE
Fix/requirements/captcha and zora

### DIFF
--- a/core/constraints/captcha.py
+++ b/core/constraints/captcha.py
@@ -60,7 +60,7 @@ class HasVerifiedHCaptcha(ConstraintVerification):
             context["request"]
         )
 
-        turnstile_token = request_context.data.get("cf-turnstile-response")
+        turnstile_token = request_context.data.get("hc-turnstile-response") or request_context.data.get("cf-turnstile-response")
 
         return request_context.ip is not None and turnstile_token is not None and hcaptcha.is_verified(
             turnstile_token, request_context.ip

--- a/core/constraints/zora.py
+++ b/core/constraints/zora.py
@@ -12,8 +12,8 @@ class DidMintZoraNFT(ConstraintVerification):
     app_name = ConstraintApp.ZORA.value
     _param_keys = [ConstraintParam.ADDRESS]
 
-    def __init__(self, user_profile) -> None:
-        super().__init__(user_profile)
+    def __init__(self, user_profile, *, obj=None) -> None:
+        super().__init__(user_profile, obj=obj)
 
     def is_observed(self, *args, **kwargs) -> bool:
         zora_util = ZoraUtil()


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix initialization issues in the DidMintZoraNFT class by adding an optional 'obj' parameter and correct the token retrieval logic in the captcha constraint to handle 'hc-turnstile-response' and 'cf-turnstile-response'.

Bug Fixes:
- Fix the initialization of DidMintZoraNFT by adding an optional 'obj' parameter to the constructor.
- Correct the retrieval of the turnstile token in the captcha constraint by checking for 'hc-turnstile-response' before 'cf-turnstile-response'.

<!-- Generated by sourcery-ai[bot]: end summary -->