### PR TITLE
modified reading tokens from headers

### DIFF
--- a/brightIDfaucet/settings.py
+++ b/brightIDfaucet/settings.py
@@ -246,6 +246,10 @@ if not DEBUG:
 else:
     CORS_ALLOW_ALL_ORIGINS = True
 
+
+# Add Turnstile response headers for CORS
+# These headers are required for Cloudflare and HCaptcha Turnstile anti-bot service
+
 CORS_ALLOW_HEADERS = list(default_headers) + [
     'cf-turnstile-response',
     'hc-turnstile-response',

--- a/brightIDfaucet/settings.py
+++ b/brightIDfaucet/settings.py
@@ -7,6 +7,8 @@ import sentry_sdk
 from dotenv import load_dotenv
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from corsheaders.defaults import default_headers
+
 from faucet.faucet_manager.bright_id_interface import BrightIDInterface
 
 load_dotenv()
@@ -243,6 +245,11 @@ if not DEBUG:
     CORS_ALLOWED_ORIGINS = WHITE_ORIGINS
 else:
     CORS_ALLOW_ALL_ORIGINS = True
+
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'cf-turnstile-response',
+    'hc-turnstile-response',
+]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/

--- a/core/constraints/captcha.py
+++ b/core/constraints/captcha.py
@@ -31,7 +31,7 @@ class HasVerifiedCloudflareCaptcha(ConstraintVerification):
             context["request"]
         )
 
-        turnstile_token = request_context.data.get("cf-turnstile-response")
+        turnstile_token = request_context.headers.get("cf-turnstile-response")
 
         return request_context.ip is not None and turnstile_token is not None and cloudflare.is_verified(
             turnstile_token, request_context.ip
@@ -60,7 +60,7 @@ class HasVerifiedHCaptcha(ConstraintVerification):
             context["request"]
         )
 
-        turnstile_token = request_context.data.get("hc-turnstile-response") or request_context.data.get("cf-turnstile-response")
+        turnstile_token = request_context.headers.get("hc-turnstile-response")
 
         return request_context.ip is not None and turnstile_token is not None and hcaptcha.is_verified(
             turnstile_token, request_context.ip


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify the method of retrieving turnstile tokens from request data to request headers and update CORS settings to allow specific headers.

Enhancements:
- Allow additional headers 'cf-turnstile-response' and 'hc-turnstile-response' in CORS settings.

<!-- Generated by sourcery-ai[bot]: end summary -->