### PR TITLE
Develop

### DIFF
--- a/authentication/models.py
+++ b/authentication/models.py
@@ -234,7 +234,7 @@ class GitcoinPassportConnection(BaseThirdPartyConnection):
     @property
     def score(self):
         _score = self.driver.submit_passport(self.user_wallet_address)
-        return _score
+        return _score if _score is not None else 0
 
 
 @receiver(pre_save, sender=GitcoinPassportConnection)

--- a/authentication/models.py
+++ b/authentication/models.py
@@ -233,8 +233,8 @@ class GitcoinPassportConnection(BaseThirdPartyConnection):
 
     @property
     def score(self):
-        score_tuple = self.driver.get_score(self.user_wallet_address)
-        return score_tuple[0] if score_tuple else 0.0
+        _score = self.driver.submit_passport(self.user_wallet_address)
+        return _score
 
 
 @receiver(pre_save, sender=GitcoinPassportConnection)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the score property in GitcoinPassportConnection to handle None values by returning 0 instead.

Bug Fixes:
- Ensure the score property in GitcoinPassportConnection returns 0 when the driver's submit_passport method returns None.

<!-- Generated by sourcery-ai[bot]: end summary -->