### PR TITLE
fix: correct formatting and add new origin to settings

### DIFF
--- a/brightIDfaucet/settings.py
+++ b/brightIDfaucet/settings.py
@@ -198,7 +198,7 @@ DATABASES = {"default": dj_database_url.config(conn_max_age=600)}
 #     }
 # }
 
-if MEMCACHED_URL and ',' in MEMCACHED_URL:
+if MEMCACHED_URL and "," in MEMCACHED_URL:
     CACHES = {
         "default": {
             "BACKEND": "django_bmemcached.memcached.BMemcached",
@@ -213,7 +213,7 @@ else:
     CACHES = {
         "default": {
             "BACKEND": "django_bmemcached.memcached.BMemcached",
-            "LOCATION": MEMCACHED_URL
+            "LOCATION": MEMCACHED_URL,
         }
     }
 
@@ -223,7 +223,7 @@ else:
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.Us"
-                "erAttributeSimilarityValidator",
+        "erAttributeSimilarityValidator",
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
@@ -251,6 +251,7 @@ WHITE_ORIGINS = [
     "https://unitap-front.vercel.app",
     "http://127.0.0.1:5678",
     "https://unitap.app",
+    "https://dashboard.unitap.app",
     "https://bright.cafepay.app",
     "https://api.unitap.app",
     "https://stage.unitap.app",


### PR DESCRIPTION
## Summary by Sourcery

Add a new allowed origin for CORS and fix formatting issues in the settings file.

New Features:
- Add `https://dashboard.unitap.app` to the list of allowed origins in the CORS settings

Bug Fixes:
- Correct the formatting of the `MEMCACHED_URL` variable by replacing single quotes with double quotes in the conditional statement.
- Fix indentation in the `AUTH_PASSWORD_VALIDATORS`  section to align with the expected Django style guide