### PR TITLE
moved corsheaders to the top of the middlewares

### DIFF
--- a/brightIDfaucet/settings.py
+++ b/brightIDfaucet/settings.py
@@ -145,10 +145,10 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     # "djangorestframework_camel_case.middleware.CamelCaseMiddleWare",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Move "corsheaders.middleware.CorsMiddleware" to be the first middleware.